### PR TITLE
feat(Cycle): remove dispose() add remember() to adapter interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export interface StreamAdapter {
   makeSubject: <T>() => Subject<T>;
   isValidStream: (stream: any) => boolean;
   streamSubscribe: StreamSubscribe;
+  cast: <T>(stream: any) => any;
 }
 
 export interface DriverFunction {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export type StreamSubscribe = (stream: any, observer: Observer) => DisposeFuncti
 
 export interface StreamAdapter {
   adapt: (originStream: any, originStreamSubscribe: StreamSubscribe) => any;
-  dispose: (sinks: any, sinkProxies: SinkProxies, sources: any) => void;
+  remember: (stream: any) => any;
   makeSubject: () => Subject;
   isValidStream: (stream: any) => boolean;
   streamSubscribe: StreamSubscribe;
@@ -47,6 +47,15 @@ export interface CycleExecution<Sources, Sinks> {
 export interface CycleSetup {
   (main: (sources: any) => any, drivers: {[name: string]: Function}): CycleExecution<any, any>;
   run: (main: (sources: any) => any, drivers: {[name: string]: Function}) => DisposeFunction;
+}
+
+function logToConsoleError(err: any) {
+  const target = err.stack || err;
+  if (console && console.error) {
+    console.error(target);
+  } else if (console && console.log) {
+    console.log(target);
+  }
 }
 
 function makeSinkProxies(drivers: DriversDefinition,
@@ -104,7 +113,16 @@ function replicateMany(sinks: any,
   const results: Array<DisposeFunction | void> = Object.keys(sinks)
     .filter(name => !!sinkProxies[name])
     .map(name =>
-      streamAdapter.streamSubscribe(sinks[name], sinkProxies[name].observer)
+      streamAdapter.streamSubscribe(sinks[name], {
+        next(x: any) { sinkProxies[name].observer.next(x); },
+        error(err: any) {
+          logToConsoleError(err);
+          sinkProxies[name].observer.error(err);
+        },
+        complete(x?: any) {
+          sinkProxies[name].observer.complete(x);
+        }
+      })
     );
   const disposeFunctions: Array<DisposeFunction> = <Array<DisposeFunction>> results
     .filter(dispose => typeof dispose === 'function');
@@ -154,7 +172,6 @@ function Cycle<Sources, Sinks>(main: (sources: Sources) => Sinks,
   const run: () => DisposeFunction = () => {
     const disposeReplication = replicateMany(sinks, sinkProxies, streamAdapter);
     return () => {
-      streamAdapter.dispose(sinks, sinkProxies, sources);
       disposeSources(sources);
       disposeReplication();
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,26 @@
-export interface Observer {
-  next: (x: any) => void;
+export interface Observer<T> {
+  next: (x: T) => void;
   error: (e: any) => void;
-  complete: (c?: any) => void;
+  complete: (c?: T) => void;
 }
 
-export interface Subject {
+export interface Subject<T> {
   stream: any;
-  observer: Observer;
+  observer: Observer<T>;
 }
 
 export interface SinkProxies {
-  [driverName: string]: Subject;
+  [driverName: string]: Subject<any>;
 }
 
 export type DisposeFunction = () => void
 
-export type StreamSubscribe = (stream: any, observer: Observer) => DisposeFunction | void
+export type StreamSubscribe = <T>(stream: any, observer: Observer<T>) => DisposeFunction | void
 
 export interface StreamAdapter {
-  adapt: (originStream: any, originStreamSubscribe: StreamSubscribe) => any;
-  remember: (stream: any) => any;
-  makeSubject: () => Subject;
+  adapt: <T>(originStream: any, originStreamSubscribe: StreamSubscribe) => any;
+  remember: <T>(stream: any) => any;
+  makeSubject: <T>() => Subject<T>;
   isValidStream: (stream: any) => boolean;
   streamSubscribe: StreamSubscribe;
 }

--- a/test/test-stream-adapter-two.js
+++ b/test/test-stream-adapter-two.js
@@ -1,14 +1,5 @@
 "use strict";
 var rxjs_1 = require('rxjs');
-function logToConsoleError(err) {
-    var target = err.stack || err;
-    if (console && console.error) {
-        console.error(target);
-    }
-    else if (console && console.log) {
-        console.log(target);
-    }
-}
 function attemptSubjectComplete(subject) {
     try {
         subject.complete();
@@ -31,24 +22,11 @@ var RxJSAdapter = {
             };
         });
     },
-    dispose: function (sinks, sinkProxies, sources) {
-        Object.keys(sources).forEach(function (k) {
-            if (typeof sources[k].unsubscribe === 'function') {
-                sources[k].unsubscribe();
-            }
-        });
-        Object.keys(sinkProxies).forEach(function (k) {
-            attemptSubjectComplete(sinkProxies[k].observer);
-        });
-    },
     makeSubject: function () {
         var stream = new rxjs_1.ReplaySubject(1);
         var observer = {
             next: function (x) { stream.next(x); },
-            error: function (err) {
-                logToConsoleError(err);
-                stream.error(err);
-            },
+            error: function (err) { stream.error(err); },
             complete: function (x) { stream.complete(); },
         };
         return { stream: stream, observer: observer };

--- a/test/test-stream-adapter.js
+++ b/test/test-stream-adapter.js
@@ -1,12 +1,5 @@
 import {ReplaySubject, Observable} from 'rx';
 
-function logToConsoleError(err) {
-  const target = err.stack || err;
-  if (console && console.error) {
-    console.error(target);
-  }
-}
-
 const testStreamAdapter = {
   adapt(originStream, originStreamSubscribe) {
     if (this.isValidStream(originStream)) {
@@ -28,25 +21,11 @@ const testStreamAdapter = {
     return destinationStream;
   },
 
-  dispose(sinks, sinkProxies, sources) {
-    Object.keys(sources).forEach(k => {
-      if (typeof sources[k].dispose === 'function') {
-        sources[k].dispose();
-      }
-    });
-    Object.keys(sinkProxies).forEach(k => {
-      sinkProxies[k].observer.complete();
-    });
-  },
-
   makeSubject() {
     const stream = new ReplaySubject(1);
     const observer = {
       next: x => stream.onNext(x),
-      error: e => {
-        logToConsoleError(e);
-        stream.onError(e);
-      },
+      error: e =>  stream.onError(e),
       complete: () => stream.onCompleted(),
     };
     return {observer, stream}


### PR DESCRIPTION
This removes the need for dispose() in the streamAdapters and adds the ability to represent "values
over time" with remember(). Also add logToConsoleError which was previously represented in every
stream adapter separately.

The StreamAdapter interface no longer has .dipose(), but now has .remember()
